### PR TITLE
[WA]Always return CodedSize for visible rect

### DIFF
--- a/components/V4L2Decoder.cpp
+++ b/components/V4L2Decoder.cpp
@@ -722,7 +722,8 @@ media::Rect V4L2Decoder::getVisibleRect(const media::Size& codedSize) {
         return media::Rect(codedSize);
     }
 
-    return rect;
+    //return rect;
+    return media::Rect(codedSize);
 }
 
 bool V4L2Decoder::sendV4L2DecoderCmd(bool start) {


### PR DESCRIPTION
When CodedSize is different with visible rect. In some NDK case,
the video can not be shown on same Rectangle.
In non-NDK case, Gallery and Chrome, this issue never happen.
Always return CodedSize for visible rect for NDK for time being.

Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>